### PR TITLE
Update Dockerfile from stretch to bookworm

### DIFF
--- a/python-nfc-pi-clock/Dockerfile
+++ b/python-nfc-pi-clock/Dockerfile
@@ -1,4 +1,4 @@
-FROM balenalib/raspberrypi3-python:3-stretch-run
+FROM balenalib/raspberrypi3-python:3-bookworm-run
 
 # use `install_packages` if you need to install dependencies,
 # for instance if you need git, just uncomment the line below.


### PR DESCRIPTION
I like the approach chosen by this repo, will expand on it and write a blog post about it. As for contributions, I want to start with the basics: Dockerfile builds with debian-stretch, which has its [support ended](https://www.debian.org/releases/stretch/).

> discontinued as of July 6th, 2020

This makes the docker compose build error out with `2.886 E: The repository 'http://deb.debian.org/debian stretch Release' does not have a Release file.`

I replaced the Dockerfile `FROM` with the most recent debian-bookworm. This makes the Docker container buildcorrectly.